### PR TITLE
Use dots as separators between the name of the key and value

### DIFF
--- a/vaultfs/vault_api.py
+++ b/vaultfs/vault_api.py
@@ -48,6 +48,10 @@ def get_secrets(payload, remote, secret_path, secret_name, full_path, data_key='
     headers = {"X-Vault-Token": _auth_payload(payload)}
     error_count = 0
     notFound = 0
+    tokenised=secret_name.split(".")
+    if len(tokenised) >= 2:
+        data_key=tokenised.pop(-1)    
+        secret_name=".".join(tokenised)
     for i in range(0,len(secret_path)):
         remote_credentials_endpoint = remote + "/v1/" + secret_path[i] + "/data/" + secret_name
         try:
@@ -86,6 +90,10 @@ def secrets_time(payload, remote, secret_path, secret_name, timeout=1):
     # maybe an object for these remote, secret_path, secret_name
     headers = {"X-Vault-Token": _auth_payload(payload)}
     exist = False
+    tokenised=secret_name.split(".")
+    if len(tokenised) >= 2:
+        data_key=tokenised.pop(-1)    
+        secret_name=".".join(tokenised)
     for i in range(0,len(secret_path)):
         remote_credentials_endpoint = remote + "/v1/" + secret_path[i] + "/metadata/" + secret_name
         try:


### PR DESCRIPTION
Instead of `data_key` always defaulting to `content`, this uses the basename of the file so that the "extension" will be understood as the name of the value within the KV2 entry. When several dots are present, only the last token is considered as being that name, the rest forming the name of the KV2 entry.

I don't know if this is a good idea, but it renders `vaultfs` much more usable as it allows access to all values that would be present in a KV2 secret engine store without enforcing any formatting at the vault level.